### PR TITLE
Implement support for NRO ASET header (icons/metadata)

### DIFF
--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -110,7 +110,7 @@ LIBTRANSISTOR_NRO_ASET_FLAGS += --version "$(NRO_VERSION)"
 endif
 
 %.nro: %.nro.so
-	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py --format nro $(LIBTRANSISTOR_NRO_ASET_FLAGS) $< $@
+	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $(LIBTRANSISTOR_NRO_ASET_FLAGS) $< $@ nro
 
 %.nso: %.nso.so
-	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py --format nso $< $@ 
+	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nso

--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -93,8 +93,20 @@ LIBTRANSISTOR_NRO_LDFLAGS := --whole-archive -ltransistor.nro --no-whole-archive
 LIBTRANSISTOR_NSO_LDFLAGS := --whole-archive -ltransistor.nso --no-whole-archive $(LIBTRANSISTOR_EXECUTABLE_LDFLAGS)
 LIBTRANSISTOR_LIB_LDFLAGS := -lc -lclang_rt.builtins-aarch64 -lc++ -lc++abi -lunwind
 
+ifneq ($(NRO_ICON),)
+LIBTRANSISTOR_NRO_ASET_FLAGS += --icon "$(NRO_ICON)"
+endif
+
+ifneq ($(NRO_NAME),)
+LIBTRANSISTOR_NRO_ASET_FLAGS += --name "$(NRO_NAME)"
+endif
+
+ifneq ($(NRO_DEVELOPER),)
+LIBTRANSISTOR_NRO_ASET_FLAGS += --developer "$(NRO_DEVELOPER)"
+endif
+
 %.nro: %.nro.so
-	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nro
+	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py --format nro $(LIBTRANSISTOR_NRO_ASET_FLAGS) $< $@
 
 %.nso: %.nso.so
-	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nso
+	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py --format nso $< $@ 

--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -105,6 +105,10 @@ ifneq ($(NRO_DEVELOPER),)
 LIBTRANSISTOR_NRO_ASET_FLAGS += --developer "$(NRO_DEVELOPER)"
 endif
 
+ifneq ($(NRO_VERSION),)
+LIBTRANSISTOR_NRO_ASET_FLAGS += --version "$(NRO_VERSION)"
+endif
+
 %.nro: %.nro.so
 	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py --format nro $(LIBTRANSISTOR_NRO_ASET_FLAGS) $< $@
 

--- a/tools/elf2nxo.py
+++ b/tools/elf2nxo.py
@@ -197,7 +197,7 @@ if __name__ == '__main__':
 		help='Output NRO/NSO file'
 	)
 	parser.add_argument(
-		'-f', '--format',
+		'format',
 		type=str,
 		default='nro',
 		choices=['nro', 'nso'],
@@ -208,30 +208,30 @@ if __name__ == '__main__':
 		'-n', '--name',
 		type=str,
 		default='',
-		help='Application name (requires `--format nro`)'
+		help='Application name (requires `nro` format)'
 	)
 	parser.add_argument(
 		'-d', '--developer',
 		type=str,
 		default='',
-		help='Application developer (requires `--format nro`)'
+		help='Application developer (requires `nro` format)'
 	)
 	parser.add_argument(
 		'-v', '--version',
 		type=str,
 		default='',
-		help='Application version (requires `--format nro`)'
+		help='Application version (requires `nro` format)'
 	)
 	parser.add_argument(
 		'-i', '--icon',
 		type=str,
 		required=False,
-		help='Path to application icon (256x256 JPEG; requires `--format nro`)'
+		help='Path to application icon (256x256 JPEG; requires `nro` format)'
 	)
 
 	args = parser.parse_args()
 
 	if args.format != 'nro' and (args.name or args.developer or args.version or args.icon):
-		parser.error('--name, --developer, --version, and --icon require --format nro')
+		parser.error('--name, --developer, --version, and --icon require `nro` format')
 
 	main(args)

--- a/tools/elf2nxo.py
+++ b/tools/elf2nxo.py
@@ -135,7 +135,7 @@ def main(args):
 				fp.write(rodata)
 				fp.write(data)
 
-				if args.name or args.developer or args.icon:
+				if args.name or args.developer or args.version or args.icon:
 					write_aset(fp, args)
 		else:
 			with open(args.outfile, 'wb') as fp:

--- a/tools/elf2nxo.py
+++ b/tools/elf2nxo.py
@@ -37,9 +37,10 @@ def write_aset(fp, args):
 			icon_size = len(icon_data)
 		
 	# Create the control.nacp structure
-	if args.name or args.developer:
+	if args.name or args.developer or args.version:
 		name_encoded = args.name.encode()[:0x200]
 		developer_encoded = args.developer.encode()[:0x100]
+		version_encoded = args.version.encode()[:0x10]
 
 		for lang_entry_index in range(12):
 			name_start = lang_entry_index * 0x300
@@ -50,6 +51,10 @@ def write_aset(fp, args):
 
 			nacp_data[name_start:name_end] = name_encoded
 			nacp_data[developer_start:developer_end] = developer_encoded
+
+		version_start = 0x3060
+		version_end = version_start + len(version_encoded)
+		nacp_data[version_start:version_end] = version_encoded
 
 	fp.write(struct.pack('<QQ', aset_size, icon_size))
 	fp.write(struct.pack('<QQ', aset_size + icon_size, nacp_size))
@@ -212,6 +217,12 @@ if __name__ == '__main__':
 		help='Application developer (requires `--format nro`)'
 	)
 	parser.add_argument(
+		'-v', '--version',
+		type=str,
+		default='',
+		help='Application version (requires `--format nro`)'
+	)
+	parser.add_argument(
 		'-i', '--icon',
 		type=str,
 		required=False,
@@ -220,7 +231,7 @@ if __name__ == '__main__':
 
 	args = parser.parse_args()
 
-	if args.format != 'nro' and (args.name or args.developer or args.icon):
-		parser.error('--name, --developer, and --icon require --format nro')
+	if args.format != 'nro' and (args.name or args.developer or args.version or args.icon):
+		parser.error('--name, --developer, --version, and --icon require --format nro')
 
 	main(args)

--- a/tools/elf2nxo.py
+++ b/tools/elf2nxo.py
@@ -6,6 +6,7 @@ from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import *
 from itertools import *
 import lz4.block
+import argparse
 
 R_AARCH64_ABS64 = 257
 R_AARCH64_ABS32 = 258
@@ -14,12 +15,54 @@ R_AARCH64_PREL64 = 260
 R_AARCH64_PREL32 = 261
 R_AARCH64_PREL16 = 262
 
+def write_aset(fp, args):
+	fp.write('ASET'.encode())
+	fp.write(struct.pack('<I', 0))
+	aset_size = 0x4 + 0x4 + 0x10 + 0x10 + 0x10
 
-def main(input, output, format='nro'):
-	format = format.lower()
-	assert format in ('nro', 'nso')
+	icon_size = 0
+	icon_data = bytes()
 
-	with open(input, 'rb') as f:
+	nacp_size = 0x4000
+	nacp_data = bytearray(nacp_size)
+
+	# Currently unsupported
+	romfs_size = 0
+	romfs_data = bytes()
+
+	# Load icon data
+	if args.icon:
+		with open(args.icon, 'rb') as fp_icon:
+			icon_data = fp_icon.read()
+			icon_size = len(icon_data)
+		
+	# Create the control.nacp structure
+	if args.name or args.developer:
+		name_encoded = args.name.encode()[:0x200]
+		developer_encoded = args.developer.encode()[:0x100]
+
+		for lang_entry_index in range(12):
+			name_start = lang_entry_index * 0x300
+			name_end = name_start + len(name_encoded)
+
+			developer_start = lang_entry_index * 0x300 + 0x200
+			developer_end = developer_start + len(developer_encoded)
+
+			nacp_data[name_start:name_end] = name_encoded
+			nacp_data[developer_start:developer_end] = developer_encoded
+
+	fp.write(struct.pack('<QQ', aset_size, icon_size))
+	fp.write(struct.pack('<QQ', aset_size + icon_size, nacp_size))
+	fp.write(struct.pack('<QQ', aset_size + icon_size + nacp_size, romfs_size))
+
+	fp.write(icon_data)
+	fp.write(nacp_data)
+	fp.write(romfs_data)
+
+def main(args):
+	format = args.format.lower()
+
+	with open(args.infile, 'rb') as f:
 		elffile = ELFFile(f)
 
 		load_segments = list(filter(lambda x: x['p_type'] == 'PT_LOAD', elffile.iter_segments()))
@@ -53,7 +96,7 @@ def main(input, output, format='nro'):
 		
 		if format == 'nro':
 			# text = text[0x80:]
-			with open(output, 'wb') as fp:
+			with open(args.outfile, 'wb') as fp:
 				dot = 0
 				
 				fp.write(code[:0x10]) # first branch instruction, mod0 offset, and padding
@@ -86,8 +129,11 @@ def main(input, output, format='nro'):
 				fp.write(code[0x80:])
 				fp.write(rodata)
 				fp.write(data)
+
+				if args.name or args.developer or args.icon:
+					write_aset(fp, args)
 		else:
-			with open(output, 'wb') as fp:
+			with open(args.outfile, 'wb') as fp:
 				ccode, crodata, cdata = [lz4.block.compress(x, store_size=False) for x in (code, rodata, data)]
 
 				fp.write('NSO0'.encode())
@@ -134,4 +180,47 @@ def main(input, output, format='nro'):
 
 
 if __name__ == '__main__':
-	sys.exit(main(*sys.argv[1:]))
+	parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+	parser.add_argument(
+		'infile', 
+		type=str, 
+		help='Input ELF file to convert to NRO/NSO'
+	)
+	parser.add_argument(
+		'outfile',
+		type=str,
+		help='Output NRO/NSO file'
+	)
+	parser.add_argument(
+		'-f', '--format',
+		type=str,
+		default='nro',
+		choices=['nro', 'nso'],
+		help='Output file format'
+	)
+
+	parser.add_argument(
+		'-n', '--name',
+		type=str,
+		default='',
+		help='Application name (requires `--format nro`)'
+	)
+	parser.add_argument(
+		'-d', '--developer',
+		type=str,
+		default='',
+		help='Application developer (requires `--format nro`)'
+	)
+	parser.add_argument(
+		'-i', '--icon',
+		type=str,
+		required=False,
+		help='Path to application icon (256x256 JPEG; requires `--format nro`)'
+	)
+
+	args = parser.parse_args()
+
+	if args.format != 'nro' and (args.name or args.developer or args.icon):
+		parser.error('--name, --developer, and --icon require --format nro')
+
+	main(args)


### PR DESCRIPTION
I modified `tools/elf2nxo.py` to support writing the ASET header for the NRO format, as per the [Switchbrew wiki][wiki]. The developer is able to supply the metadata behind the following Makefile variables:

- NRO_ICON
- NRO_NAME
- NRO_DEVELOPER
- NRO_VERSION

You can see my accompanying [pull request in reswitched/libtransistor][pr] that updates the example project with some metadata.

[wiki]: http://switchbrew.org/index.php?title=NRO#Assets
[pr]: https://github.com/reswitched/libtransistor/pull/153