### PR TITLE
fix linker error (cannnot backward)

### DIFF
--- a/link.T
+++ b/link.T
@@ -19,7 +19,7 @@ SECTIONS
     HIDDEN(__text_start = .);
     KEEP(*(.text.jmp))
 
-    . = 0x80;
+/*    . = 0x80;*/
 
     *(.text .text.*)
     *(.plt .plt.*)


### PR DESCRIPTION
A link error 'link.T:22 unable to move location counter backwards for: .text' occurred on Ubuntu 19.10.
I commented out between vector and code.

Regard.